### PR TITLE
Type2コントローラへの対応

### DIFF
--- a/TR.BIDSsvMOD.dgoCtrlUSB.sln
+++ b/TR.BIDSsvMOD.dgoCtrlUSB.sln
@@ -3,7 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TR.BIDSsvMOD.dgoCtrlUSB", "TR.BIDSsvMOD.dgoCtrlUSB\TR.BIDSsvMOD.dgoCtrlUSB.csproj", "{83FB0BB6-7D84-4290-857E-FD9A8040C723}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TR.BIDSsvMOD.dgoCtrlUSB", "TR.BIDSsvMOD.dgoCtrlUSB\TR.BIDSsvMOD.dgoCtrlUSB.csproj", "{83FB0BB6-7D84-4290-857E-FD9A8040C723}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BIDSsv", "..\BIDS_Server\BIDSsv\BIDSsv.csproj", "{D2EF98F0-8E97-4381-9A36-BFF1096267D5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBIDSsv", "..\BIDS_Server\IBIDSsv\IBIDSsv.csproj", "{91D660F1-F5E4-437E-93E0-FB13036C7953}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IAtsPI", "..\IAtsPI\IAtsPI.csproj", "{EBBBE7B7-1FFE-4F94-AA52-373BE51F670E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BIDSSMemLib.structs", "..\BIDSSMemLib\BIDSSMemLib.structs\BIDSSMemLib.structs.csproj", "{9844439C-CF70-4307-A365-56E7D8C1B12B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +23,22 @@ Global
 		{83FB0BB6-7D84-4290-857E-FD9A8040C723}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{83FB0BB6-7D84-4290-857E-FD9A8040C723}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83FB0BB6-7D84-4290-857E-FD9A8040C723}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2EF98F0-8E97-4381-9A36-BFF1096267D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2EF98F0-8E97-4381-9A36-BFF1096267D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2EF98F0-8E97-4381-9A36-BFF1096267D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2EF98F0-8E97-4381-9A36-BFF1096267D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91D660F1-F5E4-437E-93E0-FB13036C7953}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91D660F1-F5E4-437E-93E0-FB13036C7953}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91D660F1-F5E4-437E-93E0-FB13036C7953}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91D660F1-F5E4-437E-93E0-FB13036C7953}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBBBE7B7-1FFE-4F94-AA52-373BE51F670E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBBBE7B7-1FFE-4F94-AA52-373BE51F670E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBBBE7B7-1FFE-4F94-AA52-373BE51F670E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBBBE7B7-1FFE-4F94-AA52-373BE51F670E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9844439C-CF70-4307-A365-56E7D8C1B12B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9844439C-CF70-4307-A365-56E7D8C1B12B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9844439C-CF70-4307-A365-56E7D8C1B12B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9844439C-CF70-4307-A365-56E7D8C1B12B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
@@ -14,9 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="LibUsbDotNet">
-      <HintPath>..\..\..\..\..\..\Program Files\LibUsbDotNet\LibUsbDotNet.dll</HintPath>
-    </Reference>
+    <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="TR.BIDSSMemLib.structs">
       <HintPath>..\..\BIDS_Server\IBIDSsv\bin\Debug\netstandard2.0\TR.BIDSSMemLib.structs.dll</HintPath>
     </Reference>

--- a/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
@@ -8,8 +8,9 @@
     <Description>communication with D-GO Controller</Description>
     <Copyright>Copyright 2019 Tetsu Otter</Copyright>
     <AssemblyName>TR.BIDSsvMOD.dgoctrlusb</AssemblyName>
-    <AssemblyVersion>1.0.0.2</AssemblyVersion>
-    <FileVersion>1.0.0.2</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
@@ -18,15 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="TR.BIDSSMemLib.structs">
-      <HintPath>..\..\BIDS_Server\IBIDSsv\bin\Debug\netstandard2.0\TR.BIDSSMemLib.structs.dll</HintPath>
-    </Reference>
-    <Reference Include="TR.BIDSsv">
-      <HintPath>..\..\BIDS_Server\BIDSsv\bin\Debug\netstandard2.0\TR.BIDSsv.dll</HintPath>
-    </Reference>
-    <Reference Include="TR.IBIDSsv">
-      <HintPath>..\..\BIDS_Server\IBIDSsv\bin\Debug\netstandard2.0\TR.IBIDSsv.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\BIDSSMemLib\BIDSSMemLib.structs\BIDSSMemLib.structs.csproj" />
+    <ProjectReference Include="..\..\BIDS_Server\BIDSsv\BIDSsv.csproj" />
+    <ProjectReference Include="..\..\BIDS_Server\IBIDSsv\IBIDSsv.csproj" />
+    <ProjectReference Include="..\..\IAtsPI\IAtsPI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/TR.BIDSsvMOD.dgoCtrlUSB.csproj
@@ -8,9 +8,9 @@
     <Description>communication with D-GO Controller</Description>
     <Copyright>Copyright 2019 Tetsu Otter</Copyright>
     <AssemblyName>TR.BIDSsvMOD.dgoctrlusb</AssemblyName>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.1</Version>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <FileVersion>1.0.2.0</FileVersion>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TR.BIDSsvMOD.dgoCtrlUSB/main.cs
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/main.cs
@@ -125,15 +125,6 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
       keyState[10] = cKeys.Left;//C2 PDwn
       keyState[11] = cKeys.D;//D D2
 
-
-      byte buf = e.Data[4];
-      keyState[8] = (buf & 1) == 1;
-      keyState[7] = ((buf >>= 1) & 1) == 1;
-      keyState[6] = ((buf >>= 1) & 1) == 1;
-      keyState[5] = ((buf >>= 1) & 1) == 1;
-      keyState[9] = ((buf >>= 1) & 1) == 1;
-      keyState[4] = ((buf >>= 1) & 1) == 1;
-
       int RNum = Common.ReverserNum;
       int rrec = RNum;
       if (cKeys.Up & cKeys.Down)
@@ -153,60 +144,90 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
 
     private int? PNumGet(in byte[] ba, usbcom.DeviceNameList devType)
     {
+      int hdp = ba[0] & 0b00001111;
       switch (devType)
       {
         case usbcom.DeviceNameList.shinkansen:
           if (ba[1] == 0xff) return null;
-          else return (int)Math.Round(ba[1] / 18.0, MidpointRounding.AwayFromZero) - 1;
+          return (int)Math.Round(ba[1] / 18.0, MidpointRounding.AwayFromZero) - 1;
         case usbcom.DeviceNameList.type2:
-          PHandleMAX = 5;
-          BHandleMAX = 9;
-          break;
+          if (ba[1] == 0xff) return null;
+          switch (ba[1])
+          {
+            case 0x81: return 0;
+            case 0x6D: return 1;
+            case 0x54: return 2;
+            case 0x3F: return 3;
+            case 0x21: return 4;
+            case 0x00: return 5;
+            default: return null;
+          }
         case usbcom.DeviceNameList.ryojo:
-          //PHandleMAX = 13;
-          //BHandleMAX = 8;
           break;
         case usbcom.DeviceNameList.mtc_p5b8:
-          PHandleMAX = 5;
-          BHandleMAX = 8;
-          break;
+          if (hdp <= BHandleMAX) return 0;
+          return hdp - BHandleMAX - 1;
         case usbcom.DeviceNameList.mtc_p5b6:
-          PHandleMAX = 5;
-          BHandleMAX = 6;
-          break;
+          if (hdp <= BHandleMAX) return 0;
+          return hdp - BHandleMAX - 1;
       }
       return 0;
     }
     private int? BNumGet(in byte[] ba, usbcom.DeviceNameList devType)
     {
+      int hdp = ba[0] & 0b00001111;
       switch (devType)
       {
         case usbcom.DeviceNameList.shinkansen:
           if (ba[0] == 0xff) return null;
           else return (int)Math.Round(ba[0] / 28.0, MidpointRounding.AwayFromZero) - 1;
         case usbcom.DeviceNameList.type2:
-          PHandleMAX = 5;
-          BHandleMAX = 9;
-          break;
+          if (ba[1] == 0xff) return null;
+          switch (ba[0])
+          {
+            case 0xB9: return 99;
+            case 0xB5: return 8;
+            case 0xB2: return 7;
+            case 0xAF: return 6;
+            case 0xA8: return 5;
+            case 0xA2: return 4;
+            case 0x9A: return 3;
+            case 0x94: return 2;
+            case 0x8A: return 1;
+            case 0x79: return 0;
+            default: return null;
+          }
         case usbcom.DeviceNameList.ryojo:
-          //PHandleMAX = 13;
-          //BHandleMAX = 8;
           break;
         case usbcom.DeviceNameList.mtc_p5b8:
-          PHandleMAX = 5;
-          BHandleMAX = 8;
-          break;
+          if (hdp > BHandleMAX) return 0;
+          return BHandleMAX - hdp + 1;
         case usbcom.DeviceNameList.mtc_p5b6:
-          PHandleMAX = 5;
-          BHandleMAX = 6;
-          break;
+          if (hdp > BHandleMAX) return 0;
+          return BHandleMAX - hdp + 1;
       }
       return 99;
     }
     private int? RNumGet(in byte[] ba, usbcom.DeviceNameList devType)
     {
+      switch (devType)
+      {
+        case usbcom.DeviceNameList.mtc_p5b8:
+          if ((ba[0] & 0b10000000) != 0) return 1;
+          if ((ba[0] & 0b01000000) != 0) return -1;
+          return 0;
+        case usbcom.DeviceNameList.mtc_p4b8:
+          if ((ba[0] & 0b10000000) != 0) return 1;
+          if ((ba[0] & 0b01000000) != 0) return -1;
+          return 0;
+        case usbcom.DeviceNameList.mtc_p5b6:
+          if ((ba[0] & 0b00100000) != 0) return 1;
+          if ((ba[0] & 0b00010000) != 0) return -1;
+          return 0;
+      }
       return null;
     }
+
     private CtrlerKeys KeyStateGet(in byte[] ba,usbcom.DeviceNameList devType)
     {
       switch (devType)
@@ -227,12 +248,70 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
     private CtrlerKeys MTCKeyStateGet(in byte[] ba)
     {
       CtrlerKeys cKeys = new CtrlerKeys();
+      byte buf = ba[1];
+      cKeys.S = (buf & 1) == 1;
+      cKeys.D = ((buf >>= 1) & 1) == 1;
+      cKeys.A = ((buf >>= 1) & 1) == 1;
+      cKeys.APlus = ((buf >>= 1) & 1) == 1;
+      cKeys.B = ((buf >>= 1) & 1) == 1;
+      cKeys.C = ((buf >>= 1) & 1) == 1;
+
+      buf = ba[2];
+      cKeys.Start = (buf & 1) == 1;
+      cKeys.Select = ((buf >>= 1) & 1) == 1;
+      cKeys.Up = ((buf >>= 1) & 1) == 1;
+      cKeys.Down = ((buf >>= 1) & 1) == 1;
+      cKeys.Left = ((buf >>= 1) & 1) == 1;
+      cKeys.Right = ((buf >>= 1) & 1) == 1;
       return cKeys;
     }
     private CtrlerKeys DGoKeyStateGet(in byte[] ba)
     {
       CtrlerKeys cKeys = new CtrlerKeys();
+      byte buf = ba[4];
+      cKeys.D = (buf & 1) == 1;
+      cKeys.C = ((buf >>= 1) & 1) == 1;
+      cKeys.B = ((buf >>= 1) & 1) == 1;
+      cKeys.S = ((buf >>= 1) & 1) == 1;
+      cKeys.Select = ((buf >>= 1) & 1) == 1;
+      cKeys.Start = ((buf >>= 1) & 1) == 1;
+      cKeys.Horn = ba[2] == 0;
 
+      buf = ba[3];
+      if (((buf >> 3) & 1) != 1)
+      {
+        switch (ba[3] & 0b00000111)
+        {
+          case 0b000:
+            cKeys.Up = true;
+            break;
+          case 0b001:
+            cKeys.Up = true;
+            cKeys.Right = true;
+            break;
+          case 0b010:
+            cKeys.Right = true;
+            break;
+          case 0b011:
+            cKeys.Right = true;
+            cKeys.Down = true;
+            break;
+          case 0b100:
+            cKeys.Down = true;
+            break;
+          case 0b101:
+            cKeys.Down = true;
+            cKeys.Left = true;
+            break;
+          case 0b110:
+            cKeys.Left = true;
+            break;
+          case 0b111:
+            cKeys.Left = true;
+            cKeys.Up = true;
+            break;
+        }
+      }
       return cKeys;
     }
 
@@ -268,12 +347,26 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
 
     public void OnBSMDChanged(in BIDSSharedMemoryData data)
     {
-      LEDBar = (byte)Math.Ceiling(Math.Abs(data.StateData.V / SPLEDSpdCount));
-      CurrentSPD = (short)Math.Ceiling(Math.Abs(data.StateData.V));
+      if (doesHaveLamp(usbcom.DevType))
+      {
+        LEDBar = (byte)Math.Ceiling(Math.Abs(data.StateData.V / SPLEDSpdCount));
+        CurrentSPD = (short)Math.Ceiling(Math.Abs(data.StateData.V));
 
-      isDoorClosed = data.IsDoorClosed;
+        isDoorClosed = data.IsDoorClosed;
 
-      UpdateDisplay();
+        UpdateDisplay();
+      }
+    }
+
+    private bool doesHaveLamp(usbcom.DeviceNameList dn)
+    {
+      switch (dn)
+      {
+        case usbcom.DeviceNameList.ryojo: return true;
+        case usbcom.DeviceNameList.shinkansen: return true;
+        case usbcom.DeviceNameList.type2: return true;
+        default: return false;
+      }
     }
 
     private void UpdateDisplay()
@@ -326,7 +419,7 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
     public void OnOpenDChanged(in OpenD data) { }
 
     public void OnPanelDChanged(in int[] data) {
-      if (ATCPnlInd != null && data?.Length > ATCPnlInd) 
+      if (doesHaveLamp(usbcom.DevType) && ATCPnlInd != null && data?.Length > ATCPnlInd)
       {
         short atcspdRec = ATCSPD;
         ATCSPD = (short)(data[ATCPnlInd ?? 0] * MultiplNum);

--- a/TR.BIDSsvMOD.dgoCtrlUSB/main.cs
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/main.cs
@@ -6,13 +6,13 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
 {
   public class Main : IBIDSsv
   {
-    public int Version => 101;
+    public int Version => 102;
     public string Name { get; set; } = "dgoc2bids";
     public bool IsDebug { get; set; } = false;
 
     int PHandleMAX = 13;
     int CarBMax = 9;
-    int CarPMax = 9;
+    int CarPMax = 5;
     int BHandleMAX = 8;
 
     int? ATCPnlInd = null;
@@ -20,11 +20,13 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
     bool isPBExc = false;
     bool isInv = false;
     bool PCap = false;
+    int?[] BTIndex = new int?[13];
     public bool Connect(in string args)
     {
-      string[] sa = args.Replace(" ", string.Empty).Split(new string[2] { "-", "/" }, StringSplitOptions.RemoveEmptyEntries);
+      string[] sa = args.Replace(" ", string.Empty).ToLower().Split(new string[2] { "-", "/" }, StringSplitOptions.RemoveEmptyEntries);
       if (sa.Length > 1)
       {
+        for (int i = 0; i < BTIndex.Length; i++) BTIndex[i] = null;
         for (int i = 1; i < sa.Length; i++)
         {
           string[] saa = sa[i].Split(':');
@@ -51,6 +53,56 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
                   break;
                 case "pcap":
                   PCap = true;
+                  break;
+                default:
+                  if (saa[0].StartsWith("bt") && saa.Length == 2)
+                  {
+                    string btN = saa[0].Remove(0, 2);
+                    int btNAss = int.Parse(saa[1]);
+                    if (btNAss >= Common.Ctrl_Key.Length) continue;
+                    switch (btN)
+                    {
+                      case "start":
+                        BTIndex[(int)CtrlerKeysEN.Start] = btNAss;
+                        break;
+                      case "select":
+                        BTIndex[(int)CtrlerKeysEN.Select] = btNAss;
+                        break;
+                      case "s":
+                        BTIndex[(int)CtrlerKeysEN.S] = btNAss;
+                        break;
+                      case "a":
+                        BTIndex[(int)CtrlerKeysEN.A] = btNAss;
+                        break;
+                      case "aplus":
+                        BTIndex[(int)CtrlerKeysEN.APlus] = btNAss;
+                        break;
+                      case "b":
+                        BTIndex[(int)CtrlerKeysEN.B] = btNAss;
+                        break;
+                      case "c":
+                        BTIndex[(int)CtrlerKeysEN.C] = btNAss;
+                        break;
+                      case "d":
+                        BTIndex[(int)CtrlerKeysEN.D] = btNAss;
+                        break;
+                      case "up":
+                        BTIndex[(int)CtrlerKeysEN.Up] = btNAss;
+                        break;
+                      case "right":
+                        BTIndex[(int)CtrlerKeysEN.Right] = btNAss;
+                        break;
+                      case "down":
+                        BTIndex[(int)CtrlerKeysEN.Down] = btNAss;
+                        break;
+                      case "left":
+                        BTIndex[(int)CtrlerKeysEN.Left] = btNAss;
+                        break;
+                      case "horn":
+                        BTIndex[(int)CtrlerKeysEN.Horn] = btNAss;
+                        break;
+                    }
+                  }
                   break;
               }
             }
@@ -122,6 +174,7 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
       bool[] keyState = Common.Ctrl_Key;
       CtrlerKeys cKeys = KeyStateGet(e.Data, Usbcom.DevType);
 
+      /*
       keyState[0] = cKeys.Horn | cKeys.C;//Horn SW
       keyState[1] = cKeys.APlus;
       keyState[4] = cKeys.S;//S Space
@@ -132,6 +185,55 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
       keyState[9] = cKeys.Right;//C1 PUp
       keyState[10] = cKeys.Left;//C2 PDwn
       keyState[11] = cKeys.D;//D D2
+      */
+
+      for(int i = 0; i < BTIndex.Length; i++)
+      {
+        if (BTIndex[i] == null) continue;
+        int bti = BTIndex[i] ?? 0;
+        switch ((CtrlerKeysEN)i)
+        {
+          case CtrlerKeysEN.A:
+            keyState[bti] = cKeys.A;
+            break;
+          case CtrlerKeysEN.APlus:
+            keyState[bti] = cKeys.APlus;
+            break;
+          case CtrlerKeysEN.B:
+            keyState[bti] = cKeys.B;
+            break;
+          case CtrlerKeysEN.C:
+            keyState[bti] = cKeys.C;
+            break;
+          case CtrlerKeysEN.D:
+            keyState[bti] = cKeys.D;
+            break;
+          case CtrlerKeysEN.Down:
+            keyState[bti] = cKeys.Down;
+            break;
+          case CtrlerKeysEN.Horn:
+            keyState[bti] = cKeys.Horn;
+            break;
+          case CtrlerKeysEN.Left:
+            keyState[bti] = cKeys.Left;
+            break;
+          case CtrlerKeysEN.Right:
+            keyState[bti] = cKeys.Right;
+            break;
+          case CtrlerKeysEN.S:
+            keyState[bti] = cKeys.S;
+            break;
+          case CtrlerKeysEN.Select:
+            keyState[bti] = cKeys.Select;
+            break;
+          case CtrlerKeysEN.Start:
+            keyState[bti] = cKeys.Start;
+            break;
+          case CtrlerKeysEN.Up:
+            keyState[bti] = cKeys.Up;
+            break;
+        }
+      }
 
       int RNum = Common.ReverserNum;
       int rrec = RNum;
@@ -346,6 +448,22 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
       return cKeys;
     }
 
+    public enum CtrlerKeysEN
+    {
+      Start,
+      Select,
+      S,
+      A,
+      APlus,
+      B,
+      C,
+      D,
+      Up,
+      Right,
+      Down,
+      Left,
+      Horn
+    }
     public struct CtrlerKeys
     {
       public bool Start;
@@ -477,7 +595,8 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
     {
       Console.WriteLine("communicate with dgocon\n" +
         " -a : (atc) set the atc panel number (default : null)" +
-        " -m : (magnification) set the magnification number that multiply with ATC Panel value"+
+        " -btXXX : (brake) assign the work to button (default : null)(XXX:start, select etc)" +
+        " -m : (magnification) set the magnification number that multiply with ATC Panel value" +
         " -n : (name) set the name of this connection"+
         " -pbexc : (Power / Brake Exchange) Exchange roles of Power Handle and Brake Handle"+
         " -pcap : Only do Packet Capture" +

--- a/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
@@ -15,8 +15,8 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
     //static UsbDeviceFinder uDevFinder = new UsbDeviceFinder(0x0AE4, 0x0005);
     static UsbDeviceFinder[] uDevFinder = new UsbDeviceFinder[8]
     {
-      new UsbDeviceFinder(0x0AE4, 0x0005),//Shinkansen
       new UsbDeviceFinder(0x0AE4, 0x0004),//type2
+      new UsbDeviceFinder(0x0AE4, 0x0005),//Shinkansen
       new UsbDeviceFinder(0x0AE4, 0x0006),//ryojo
       new UsbDeviceFinder(0x0AE4, 0x0101),//mtc_p5b8
       new UsbDeviceFinder(0x1C06, 0x77A7),//mtc_p5b6
@@ -28,7 +28,7 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
 
     public enum DeviceNameList
     {
-      None, shinkansen, type2, ryojo, mtc_p5b8, mtc_p5b6, mtc_p4b8, mtc_p4B8_tq, mtc_p13b8
+      None, type2, shinkansen, ryojo, mtc_p5b8, mtc_p5b6, mtc_p4b8, mtc_p4B8_tq, mtc_p13b8
     }
 
     static public DeviceNameList DevType { get; private set; } = DeviceNameList.None;
@@ -43,7 +43,7 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
           if (uDevice == null) continue;
           DevType = (DeviceNameList)i + 1;
         }
-
+        Console.WriteLine("Device was found.  DevType is {0} (VID : {1}, PID : {2})", DevType, uDevice.UsbRegistryInfo.Vid, uDevice.UsbRegistryInfo.Pid);
         IUsbDevice iuDev = uDevice as IUsbDevice;
         if (!ReferenceEquals(iuDev, null))
         {

--- a/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
@@ -9,7 +9,7 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
 {
   //Ref : https://www.ipentec.com/document/libusbdotnet-app-create
 
-  class usbcom
+  class Usbcom
   {
     static UsbDevice uDevice;
     //static UsbDeviceFinder uDevFinder = new UsbDeviceFinder(0x0AE4, 0x0005);

--- a/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
@@ -39,9 +39,22 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
       {
         for(int i = 0; i < (int)DeviceNameList.mtc_p5b6; i++)
         {
-          uDevice = UsbDevice.OpenUsbDevice(uDevFinder[i]);
+          try
+          {
+            uDevice = UsbDevice.OpenUsbDevice(uDevFinder[i]);
+          }catch(Exception e)
+          {
+            Console.WriteLine("usbcom Opening Process : {0}", e);
+            throw;
+          }
           if (uDevice == null) continue;
           DevType = (DeviceNameList)i + 1;
+          break;
+        }
+        if(uDevice == null)
+        {
+          Console.WriteLine("Usb Finding Process : Device not found.");
+          return;
         }
         Console.WriteLine("Device was found.  DevType is {0} (VID : {1}, PID : {2})", DevType, uDevice.UsbRegistryInfo.Vid, uDevice.UsbRegistryInfo.Pid);
         IUsbDevice iuDev = uDevice as IUsbDevice;
@@ -50,12 +63,12 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
           iuDev.SetConfiguration(1);
           iuDev.ClaimInterface(0);
         }
-        uDevice.Open();
+        uDevice?.Open();
         
       }
       catch(Exception e)
       {
-        Console.WriteLine("usbcom Connecting Proces : {0}", e);
+        Console.WriteLine("usbcom Connecting Process : {0}", e);
         throw;
       }
       (new Thread(() => {
@@ -95,7 +108,7 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
 
     public static void Close()
     {
-      uDevice.Close();
+      uDevice?.Close();
     }
   }
 }

--- a/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
@@ -17,7 +17,7 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
     {
       new UsbDeviceFinder(0x0AE4, 0x0005),//Shinkansen
       new UsbDeviceFinder(0x0AE4, 0x0004),//type2
-      new UsbDeviceFinder(0x0AE4, 0x0006),//ryojo
+      new UsbDeviceFinder(0x0AE4, 0x0007),//ryojo
       new UsbDeviceFinder(0x0AE4, 0x0101),//mtc_p5b8
       new UsbDeviceFinder(0x1C06, 0x77A7),//mtc_p5b6
       new UsbDeviceFinder(0x0000, 0x0000),//mtc_p4b8

--- a/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
+++ b/TR.BIDSsvMOD.dgoCtrlUSB/usbcom.cs
@@ -11,20 +11,38 @@ namespace TR.BIDSsvMOD.dgoCtrlUSB
 
   class usbcom
   {
-    public static UsbDevice uDevice;
-    public static UsbDeviceFinder uDevFinder = new UsbDeviceFinder(0x0AE4, 0x0005);
+    static UsbDevice uDevice;
+    //static UsbDeviceFinder uDevFinder = new UsbDeviceFinder(0x0AE4, 0x0005);
+    static UsbDeviceFinder[] uDevFinder = new UsbDeviceFinder[8]
+    {
+      new UsbDeviceFinder(0x0AE4, 0x0005),//Shinkansen
+      new UsbDeviceFinder(0x0AE4, 0x0004),//type2
+      new UsbDeviceFinder(0x0AE4, 0x0006),//ryojo
+      new UsbDeviceFinder(0x0AE4, 0x0101),//mtc_p5b8
+      new UsbDeviceFinder(0x1C06, 0x77A7),//mtc_p5b6
+      new UsbDeviceFinder(0x0000, 0x0000),//mtc_p4b8
+      new UsbDeviceFinder(0x0000, 0x0000),//mtc_p4b8_tq
+      new UsbDeviceFinder(0x0000, 0x0000) //mtc_p13b8
+    };
+
 
     public enum DeviceNameList
     {
-      TCPP20011
+      None, shinkansen, type2, ryojo, mtc_p5b8, mtc_p5b6, mtc_p4b8, mtc_p4B8_tq, mtc_p13b8
     }
+
+    static public DeviceNameList DevType { get; private set; } = DeviceNameList.None;
     
-    public static void Connect(DeviceNameList dList)
+    public static void Connect()
     {
       try
       {
-        if((uDevice = UsbDevice.OpenUsbDevice(uDevFinder)) == null)
-          throw new Exception("Device Not Found");
+        for(int i = 0; i < (int)DeviceNameList.mtc_p5b6; i++)
+        {
+          uDevice = UsbDevice.OpenUsbDevice(uDevFinder[i]);
+          if (uDevice == null) continue;
+          DevType = (DeviceNameList)i + 1;
+        }
 
         IUsbDevice iuDev = uDevice as IUsbDevice;
         if (!ReferenceEquals(iuDev, null))


### PR DESCRIPTION
## 対応したコントローラ一覧
- 新幹線編(PS2 継続)
- type2(PS2 知らせ灯を除く)
- 旅情編(UNBALANCE)
- MTC(P5B7, P5B5カセット 未検証)
- 旅情編(PS2 未検証)

## 追加機能
- Power / Brake Lever Role Exchange
  - 力行ハンドルと制動ハンドルの役割を交換します。  
旅情編は未対応です。
- Lever Direction Reversal
  - ハンドルの段の増減方向を逆転させます。  
旅情編は未対応です。
- Ability to change the role of a button
  - ボタンの役割を任意に設定することが可能です。
